### PR TITLE
Ignore i2c mouse devices

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -38,8 +38,8 @@ var DEBUG_TO_FILE = false;
 const TOUCHPADS = ['touchpad', 'glidepoint', 'fingersensingpad', 'bcm5974', 'trackpad', 'smartpad'];
 const TRACKPOINTS = ['trackpoint', 'accu point', 'trackstick', 'touchstyk', 'pointing stick', 'dualpoint stick'];
 const TOUCHSCREENS = ['touchscreen', 'maxtouch', 'touch digitizer', 'touch system'];
-const FINGERTOUCHES = ['finger touch'];
-const PENS = ['pen stylus', 'pen eraser'];
+const FINGERTOUCHES = ['finger touch', 'finger'];
+const PENS = ['pen stylus', 'pen eraser', 'pen'];
 const OTHERS = [];
 var ALL_TYPES = {
     'touchpad': TOUCHPADS,

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
     "uuid": "touchpad-indicator@orangeshirt",
     "shell-version": [
         "3.38",
-        "40"
+        "40",
+        "41"
     ],
     "gettext-domain": "touchpad-indicator",
     "url": "https://github.com/user501254/TouchpadIndicator#touchpadindicator",


### PR DESCRIPTION
## Description
Ignore i2c mouse devices. [Already known issue](https://askubuntu.com/a/1280008).

Works like a charm on my Dell XPS 15 9560.

## WARNING
**To be deeply tested with other PC vendors/products !**

I haven't tested it with other PC than mine, but I can suppose that the devices interaction with i2c kernel modules is the same. 

## Related Issues
Maybe related  issues are: #40, #61, #64 and #67.

For #67 I think that i2c devices are one problem. The other is multiple mouse connected/discovered.

## System info
![image](https://user-images.githubusercontent.com/616846/153757384-5e0d6ba5-023c-42e7-93b7-a59fa8168f9e.png)

## Devices:
![image](https://user-images.githubusercontent.com/616846/153757218-1ac4f0f6-154d-4f34-9525-c392fde3f32a.png)

## Extension devices:
![image](https://user-images.githubusercontent.com/616846/153757165-e629973d-dcc0-4690-ac04-fcab3e9e2e25.png)
